### PR TITLE
[BUGFIX] Register table definitions for nested backends

### DIFF
--- a/Classes/MultilevelCacheBackend.php
+++ b/Classes/MultilevelCacheBackend.php
@@ -205,6 +205,24 @@ class MultilevelCacheBackend extends AbstractBackend implements BackendInterface
     }
 
     /**
+     * Returns the needed schema for nested backends.
+     *
+     * @return string
+     */
+    public function getTableDefinitions()
+    {
+        $tableDefinitions = '';
+        foreach ($this->backends as $backendConfig) {
+            $backend = $backendConfig['instance'];
+            if (method_exists($backend, 'getTableDefinitions')) {
+                $tableDefinitions .= LF . $backend->getTableDefinitions();
+            }
+        }
+
+        return $tableDefinitions;
+    }
+
+    /**
      * @param array $delegate
      * @param string $entryIdentifier
      * @return string


### PR DESCRIPTION
The Install Tool Schema Service provides additional schema information for
cache backends that implement the `getTableDefinitions` method.

This changeset amends the MultilevelCacheBackend so that it creates the
needed schema for nested backends.